### PR TITLE
fix: update https plugin repository URL in plugin configuration

### DIFF
--- a/notes/coredns-1.12.2.1.md
+++ b/notes/coredns-1.12.2.1.md
@@ -1,0 +1,22 @@
++++
+title = "CoreDNS-1.12.2.1 Release"
+description = "CoreDNS-1.12.2.1 Release Notes."
+tags = ["Release", "1.12.2.1", "Notes"]
+release = "1.12.2.1"
+date = "2024-06-28T00:00:00+00:00"
+author = "coredns"
++++
+
+This release updates the plugin.cfg file to change the source of the https plugin.
+
+## HTTPS plugin
+
+### HTTP/3 Support
+
+Added support for HTTP/3 in the HTTPS plugin by introducing a new httpVersion configuration property in setup.go.
+Implemented logic to configure HTTP clients based on the specified httpVersion (defaulting to HTTP/2) and added QUIC-specific settings for HTTP/3.
+
+### Configuration Enhancements
+
+Extended the httpsConfig struct to include an httpVersion field, defaulting to HTTP2.0.
+Added a new http_version directive to the CoreDNS configuration parser, allowing users to specify HTTP/2 or HTTP/3.

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -74,4 +74,4 @@ on:github.com/coredns/caddy/onevent
 sign:sign
 view:view
 fanout:github.com/networkservicemesh/fanout
-https:github.com/v-byte-cpu/coredns-https
+https:github.com/paweenruk/coredns-https


### PR DESCRIPTION
This pull request updates the `plugin.cfg` file to change the source of the `https` plugin.

* [`plugin.cfg`](diffhunk://#diff-b4e59ee676115519545c5bedf117fdff14506f9429fa10214be69a1352a87e0fL77-R77): Updated the `https` plugin to use the repository `github.com/paweenruk/coredns-https` instead of `github.com/v-byte-cpu/coredns-https`.