### PR TITLE
Feature/change https dependency

### DIFF
--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 // Various CoreDNS constants.
 const (
-	CoreVersion = "1.12.2"
+	CoreVersion = "1.12.2.1"
 	CoreName    = "CoreDNS"
 	serverType  = "dns"
 )


### PR DESCRIPTION
This pull request introduces several updates to the CoreDNS project, focusing on Docker workflow improvements, version updates, and plugin configuration enhancements. Key changes include modifying Docker commands to use a new repository, updating the CoreDNS version to `1.12.2.1`, and adding support for new plugins and HTTP/3 in the HTTPS plugin.

### Docker Workflow Updates:
* Updated Docker build and publish commands in `.github/workflows/docker.yml` to use `paweenruk` as the Docker repository and added a GitHub release URL. (`[[1]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L25-R25)`, `[[2]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L34-R34)`)

### CoreDNS Version Update:
* Updated the CoreDNS version from `1.12.2` to `1.12.2.1` in `coremain/version.go`. (`[coremain/version.goL5-R5](diffhunk://#diff-179a1bdcf9fe4d4675e4cfe57406cb70b75de872afc69a2ae308ae4619a2741aL5-R5)`)

### Plugin Configuration Enhancements:
* Added `fanout` and `https` plugins to `plugin.cfg`. (`[plugin.cfgR76-R77](diffhunk://#diff-b4e59ee676115519545c5bedf117fdff14506f9429fa10214be69a1352a87e0fR76-R77)`)
* Enhanced the HTTPS plugin to support HTTP/3 by introducing a new `httpVersion` configuration property and extending the configuration parser to allow specifying HTTP/2 or HTTP/3. (`[notes/coredns-1.12.2.1.mdR1-R22](diffhunk://#diff-a8cba906cdf2ba888625448846067521f1815c5900ecc4c3ea7e562d08a93d80R1-R22)`)

### Build and Release Process Updates:
* Updated the `Makefile` to reference the new repository path for building CoreDNS. (`[MakefileL19-R20](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L19-R20)`)
* Modified the `Makefile.release` to update pull request links to the new repository. (`[Makefile.releaseL140-R140](diffhunk://#diff-3d6bb466de3c144c10970dff9d469845f107de4f1288364997362e3d96239235L140-R140)`)

### Dependency Update:
* Bumped the version of `github.com/go-viper/mapstructure/v2` from `v2.2.1` to `v2.3.0` in `go.mod`. (`[go.modL110-R110](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L110-R110)`)